### PR TITLE
Add GitHub Actions workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,7 +10,7 @@ jobs:
       fail-fast: true
       matrix:
         elixir: [1.9.x, 1.8.x, 1.7.x]
-        otp: [22.3, 21.2, 19.x]
+        otp: [22.3, 21.2, 19.2]
 
     env:
       MIX_ENV: test

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,7 +10,7 @@ jobs:
       fail-fast: true
       matrix:
         elixir: [1.9.x, 1.8.x, 1.7.x]
-        otp: [22.3, 21.2, 19.2]
+        otp: [22.3, 21.2, 18.3]
 
     env:
       MIX_ENV: test

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,7 +10,7 @@ jobs:
       fail-fast: true
       matrix:
         elixir: [1.9.x, 1.8.x, 1.7.x]
-        otp: [22.3, 21.2, 18.3]
+        otp: [22.3, 21.2, 20.2]
 
     env:
       MIX_ENV: test

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,41 @@
+name: Continuous Integration
+
+on: ['push', 'pull_request']
+
+jobs:
+  ci:
+    runs-on: ubuntu-latest
+
+    strategy:
+      fail-fast: true
+      matrix:
+        elixir: [1.9.x, 1.8.x, 1.7.x]
+        otp: [22.3, 21.2, 19.x]
+
+    env:
+      MIX_ENV: test
+
+    name: CI - Elixir ${{ matrix.elixir }} - OTP ${{ matrix.otp }}
+
+    steps:
+
+    - name: Checkout
+      uses: actions/checkout@v2
+
+    - name: Setup Elixir
+      uses: actions/setup-elixir@v1
+      with:
+        elixir-version: ${{ matrix.elixir }}
+        otp-version: ${{ matrix.otp }}
+
+    - name: Install Mix dependencies
+      run: mix deps.get
+
+    - name: Upload coverage to Coveralls
+      run: mix coveralls.travis
+
+    - name: Install Mix dependencies
+      run: MIX_ENV=docs mix deps.get
+
+    - name: Upload report to Inch
+      run: MIX_ENV=docs mix inch.report


### PR DESCRIPTION
I think, as mentioned [in Gitter](https://gitter.im/tldr-pages/tldr?at=5ebc6dd920eaac185309c6cc), it would be good to move to GitHub Actions for our workflows instead of Travis.

I have created a workflow file that uses the [Setup Elixir](https://github.com/actions/setup-elixir) action however it seems to be failing on the `mix deps.get` call:
https://github.com/owenvoke/extldr/runs/674015656?check_suite_focus=true#step:4:1

```
init terminating in do_boot ()
{"init terminating in do_boot",{undef,[{elixir,start_cli,[],[]},{init,start_em,1,[]},{init,do_boot,3,[]}]}}

Crash dump is being written to: erl_crash.dump...done
##[error]Process completed with exit code 1.
```

I haven't really got any experience with Elixir, so @ivanhercaz, do you have any ideas? 🤔 It seemed to be complaining previously about unsupported versions, so perhaps this is due to a version missmatch between OTP and Elixir? 🤷