### PR TITLE
gh-actions: fix ExCoveralls building

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,6 +14,7 @@ jobs:
 
     env:
       MIX_ENV: test
+      GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
     name: CI - Elixir ${{ matrix.elixir }} - OTP ${{ matrix.otp }}
 
@@ -32,7 +33,7 @@ jobs:
       run: mix deps.get
 
     - name: Upload coverage to Coveralls
-      run: mix coveralls.travis
+      run: mix coveralls.github
 
     - name: Install Mix dependencies
       run: MIX_ENV=docs mix deps.get


### PR DESCRIPTION
As I specified on #16, it seems that Coveralls report isn't working and [returning errors](https://github.com/tldr-pages/extldr/actions/runs/104695716). I think it is because we did not consider to configure ExCoveralls for GitHub Actions as it is specified in [its README](https://github.com/parroty/excoveralls#mix-coverallsgithub-post-coverage-from-github-actions).

This PR change set the `GITHUB_TOKEN` to `{{ secrets.GITHUB_TOKEN }}` and the script to report to `mix coveralls.github`.

**PS**. I don't know the reason why my commits is unverified :/ I always sign them.