### PR TITLE
Use `main` branch instead of `master`

### DIFF
--- a/lib/ex_tldr.ex
+++ b/lib/ex_tldr.ex
@@ -48,7 +48,7 @@ defmodule ExTldr do
   defp process(os, term), do: describe(os, term)
 
   defp process_url(os, term) do
-    "https://raw.githubusercontent.com/tldr-pages/tldr/master/pages/#{os}/#{term}.md"
+    "https://raw.githubusercontent.com/tldr-pages/tldr/main/pages/#{os}/#{term}.md"
   end
 
   defp process_os_term(:help), do: process(:help)


### PR DESCRIPTION
[About 1.5 years ago](https://github.com/tldr-pages/tldr/discussions/5868), we deprecated the `master` branch in favor of the `main` branch. We intend to remove it [soon, likely by May 1st 2023](https://github.com/tldr-pages/tldr/issues/9628).