### PR TITLE
ci: pin ubuntu version

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,7 +4,7 @@ on: ['push', 'pull_request']
 
 jobs:
   ci:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-18.04
 
     strategy:
       fail-fast: true


### PR DESCRIPTION
PR pins the version of Ubuntu used to run the CI workflow to `ubuntu-18.04`. No newer version of Ubuntu works out of the box as the installation of elixir requires `libcrypto.so.1.0.0` which comes from the `libssl1.0.0` package which was last available for Ubuntu 18.04. 

A better long term solution would be to switch to using `erlef/setup-beam@v1` for the elixir installation as `actions/setup-elixir` has been deprecated in favor of it, and the former is still supported and _should_ be usable, but doing so would require changing the version constraints that are passed in, and that'd be better suited to someone who knows the elixir ecosystem and what these values mean as I do not.